### PR TITLE
Dependency Fixes And Mod Loading Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,9 @@ repositories {
     maven { url = "https://maven.blamejared.com/" }
 
 
+    maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
+    maven { url = "https://maven.ithundxr.dev/mirror" } // Registrate
+    maven { url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/" } // ForgeConfigAPIPort
 
 
 }
@@ -151,19 +154,21 @@ dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
 
+    implementation(fg.deobf("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false })
+    implementation(fg.deobf("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_version}"))
+    compileOnly(fg.deobf("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:${flywheel_version}"))
+    runtimeOnly(fg.deobf("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_version}"))
+    implementation(fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}"))
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
+    implementation("io.github.llamalad7:mixinextras-forge:0.4.1")
 
-    dependencies {
-        implementation fg.deobf("com.simibubi.create:create-${create_minecraft_version}:${create_version}:slim") { transitive = false }
-        implementation fg.deobf("com.jozufozu.flywheel:flywheel-forge-${flywheel_minecraft_version}:${flywheel_version}")
-        implementation fg.deobf("com.tterrag.registrate:Registrate:${registrate_version}")
-        implementation(fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}"))
-    }
-    dependencies {
-        implementation fg.deobf("curse.maven:timeless-and-classics-zero-1028108:6654541")
-    }
+    implementation(fg.deobf("mezz.jei:jei-${minecraft_version}-forge:${jei_version}"))
 
 
-        // Example mod dependency using a mod jar from ./libs with a flat dir repository
+    implementation fg.deobf("curse.maven:timeless-and-classics-zero-1028108:6654541")
+
+
+    // Example mod dependency using a mod jar from ./libs with a flat dir repository
     // This maps to ./libs/coolmod-${mc_version}-${coolmod_version}.jar
     // The group id is ignored when searching -- in this case, it is "blank"
     // implementation fg.deobf("blank:coolmod-${mc_version}:${coolmod_version}")
@@ -179,11 +184,11 @@ dependencies {
 // See https://docs.gradle.org/current/dsl/org.gradle.language.jvm.tasks.ProcessResources.html
 tasks.named('processResources', ProcessResources).configure {
     var replaceProperties = [
-            minecraft_version: minecraft_version, minecraft_version_range: minecraft_version_range,
-            forge_version: forge_version, forge_version_range: forge_version_range,
+            minecraft_version   : minecraft_version, minecraft_version_range: minecraft_version_range,
+            forge_version       : forge_version, forge_version_range: forge_version_range,
             loader_version_range: loader_version_range,
-            mod_id: mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
-            mod_authors: mod_authors, mod_description: mod_description,
+            mod_id              : mod_id, mod_name: mod_name, mod_license: mod_license, mod_version: mod_version,
+            mod_authors         : mod_authors, mod_description: mod_description,
     ]
     inputs.properties replaceProperties
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,8 @@ mod_description=This mod adds immersive Create recipes for TaCZ.
 
 create_minecraft_version = 1.20.1
 flywheel_minecraft_version = 1.20.1
-create_version = 0.5.1.j-55
-flywheel_version = 0.6.11-13
+create_version = 6.0.4-110
+flywheel_version = 1.0.4
+ponder_version = 1.0.80
 registrate_version = MC1.20-1.3.3
 jei_version = 15.2.0.22

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ minecraft_version=1.20.1
 # as they do not follow standard versioning conventions.
 minecraft_version_range=[1.20.1,1.21)
 # The Forge version must agree with the Minecraft version to get a valid artifact
-forge_version=47.3.12
+forge_version=47.3.0
 # The Forge version range can use any version of Forge as bounds or match the loader version range
 forge_version_range=[47,)
 # The loader version range can only use the major version of Forge/FML as bounds

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ mod_name=Create Immersive TaCZ
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=1.3-1.20.1
+mod_version=1.4-1.20.1
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/net/myr/createimmersivetacz/CreateImmersiveTacz.java
+++ b/src/main/java/net/myr/createimmersivetacz/CreateImmersiveTacz.java
@@ -10,6 +10,7 @@ import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
 import net.minecraftforge.event.server.ServerStartingEvent;
 import net.minecraftforge.eventbus.api.IEventBus;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.ModLoadingContext;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.config.ModConfig;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -33,9 +34,9 @@ public class CreateImmersiveTacz
     // Create a Deferred Register to hold Blocks which will all be registered under the "examplemod" namespace
 
 
-    public CreateImmersiveTacz(FMLJavaModLoadingContext context)
+    public CreateImmersiveTacz()
     {
-        IEventBus modEventBus = context.getModEventBus();
+        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
 
         ModCreativeModeTabs.register(modEventBus);
 
@@ -50,7 +51,7 @@ public class CreateImmersiveTacz
 
         modEventBus.addListener(this::addCreative);
 
-        context.registerConfig(ModConfig.Type.COMMON, Config.SPEC);
+        ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, Config.SPEC);
 
     }
 


### PR DESCRIPTION
Cleaned and updated the mod's dependencies. The mod's codes now depend on create `6.0.4`. However, I did NOT change `mods.toml` and the mod still works with create `0.5.1.j` (tested).

I downgraded the forge version from `47.3.12` to `47.3.0` and changed the mod's loading method to the old fashioned way (0-arg constructor). This way, users are no longer required to upgrade their forge which is quite troublesome if they are adding this mod to existing modpacks. Nonetheless, the mod is still compatible with forge `47.4.0` (the latest version) on minecraft `1.20.1` (tested). You probably have to revert this change for the mod to work in minecraft `1.21` though.

Though already stated in the `LICENSE` file (MIT), I'd still like to double check if I have the permission to redistribute this modified version of your mod if this PR gets reject?